### PR TITLE
harmonize requirements with PyPi distribution

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,28 +12,25 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
-    - python >=3.6,<3.10
+    - python >=3.7
     - pip
     - pytest-runner
   run:
-    - python >=3.6,<3.10
+    - python >=3.7
+    - contextlib2 >=0.5.5
     - pandas >=0.15
+    - numpy 
     - pyyaml >=3.11
     - requests >=2.21
     - requests-toolbelt >=0.6
-    - trafaret <2.0,>=0.7,!=1.1.0
+    - trafaret !=1.1.0,<2.2,>=0.7
     - urllib3 >=1.23
-    - attrs >=19.1.0,<20.0
-    - contextlib2 >=0.5.5
-    - numpy
-    - python-dateutil
-    - pytz
-    - six
+    - typing-extensions ==4.3.0
 
 test:
   imports:


### PR DESCRIPTION
harmonize requirements with those specified in the PyPi distribution's requires.txt for v3.0.2

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

@conda-forge-admin, please rerender

<!--
Please add any other relevant info below:
-->

Over time, it seems that the requirements for the PyPi and Conda-Forge distributions of `datarobot` have gotten out of sync. See brief discussion of this issue, and the problems we thus had installing datarobot in some of our environments, [here](https://community.datarobot.com/t5/datarobot-api/requirements-do-not-match-between-pypi-and-conda-forge/m-p/16054#M44). This PR suggests replacing the conda-forge recipe's requirements with those in the `requires.txt` file of the version 3.0.2 distribution from PyPi. Building this recipe locally works, and seems to resolve the incompatibility issues.

Thank you, and best wishes,
\--
Ryan H